### PR TITLE
Switch to 'bizstyle' theme to make working with the docs easier

### DIFF
--- a/doc_source/conf.py
+++ b/doc_source/conf.py
@@ -121,7 +121,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'bizstyle'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The original 'alabaster' theme is hard to work with when making changes. Switched to 'bizstyle' to match the Java user guide doc repo.