### PR TITLE
Fixed typo in "Manually Adding a Profile" section

### DIFF
--- a/doc_source/credentials.md
+++ b/doc_source/credentials.md
@@ -72,7 +72,7 @@ aws_access_key_id = YOUR_ACCESS_KEY_ID
 aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
 ```
 
-You can use a role by creating a profile for the role\. The following example shows a role profile named `assumed-role` that is assumed by the default profile\.
+You can use a role by creating a profile for the role\. The following example shows a role profile named `assume-role-test` that is assumed by the default profile\.
 
 ```
 [assume-role-test]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Typo was referring to a role name when it should have been referring to a profile name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
